### PR TITLE
Support loading multiple descriptors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1131,7 +1131,11 @@ dependencies = [
  "moka",
  "prost",
  "prost-reflect",
+ "prost-types",
+ "serde",
+ "serde_yaml",
  "sha2",
+ "tempfile",
  "tokio",
  "tonic",
  "tonic-build",
@@ -1172,6 +1176,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
 
 [[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1207,6 +1217,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap 2.10.0",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -1541,6 +1564,12 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,11 +8,17 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 tonic = { version = "0.11", features = ["transport"] }
 prost = "0.12"
 prost-reflect = "0.12"
+prost-types = "0.12"
 clap = { version = "4", features = ["derive"] }
 hyper = { version = "0.14", features = ["full"] }
 bytes = "1"
 moka = { version = "0.12", features = ["future"] }
 sha2 = "0.10"
+serde = { version = "1", features = ["derive"] }
+serde_yaml = "0.9"
+
+[dev-dependencies]
+tempfile = "3"
 
 [build-dependencies]
 tonic-build = "0.11"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, net::SocketAddr, path::PathBuf};
+use std::{net::SocketAddr, path::PathBuf};
 
 use clap::Parser;
 use rtc::proxy::{self, ProxyConfig};
@@ -6,9 +6,9 @@ use rtc::proxy::{self, ProxyConfig};
 #[derive(Parser, Debug)]
 #[command(author, version, about)]
 struct Args {
-    /// Path to binary FileDescriptorSet
+    /// Root directory containing service descriptors
     #[arg(long)]
-    descriptor: PathBuf,
+    descriptor_root: PathBuf,
 
     /// Address to listen on
     #[arg(long, default_value = "127.0.0.1:50051")]
@@ -17,28 +17,16 @@ struct Args {
     /// Default upstream gRPC endpoint (e.g. http://localhost:50052)
     #[arg(long)]
     default: String,
-
-    /// Mapping from fully qualified method name to upstream URI (e.g. package.Service/Method=http://host:port)
-    #[arg(long)]
-    route: Vec<String>,
 }
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let args = Args::parse();
 
-    let mut routes = HashMap::new();
-    for r in args.route {
-        if let Some((method, uri)) = r.split_once('=') {
-            routes.insert(format!("/{}", method.trim_start_matches('/')), uri.parse()?);
-        }
-    }
-
     let config = ProxyConfig {
-        descriptor_path: args.descriptor,
+        descriptor_root: args.descriptor_root,
         listen: args.listen,
         default: args.default.parse()?,
-        routes,
     };
 
     proxy::serve(config).await

--- a/tests/proxy_integration.rs
+++ b/tests/proxy_integration.rs
@@ -1,6 +1,11 @@
-use std::{collections::HashMap, net::SocketAddr, path::PathBuf, time::Duration};
+use std::{fs, net::SocketAddr, path::PathBuf, time::Duration};
 
-use rtc::{proxy::{self, ProxyConfig}, server};
+use tempfile::TempDir;
+
+use rtc::{
+    proxy::{self, ProxyConfig},
+    server,
+};
 use tonic::Request;
 
 pub mod test {
@@ -12,33 +17,39 @@ async fn proxy_forwards_requests() {
     let server_addr: SocketAddr = "127.0.0.1:50052".parse().unwrap();
     let proxy_addr: SocketAddr = "127.0.0.1:50053".parse().unwrap();
     let descriptor = PathBuf::from(concat!(env!("CARGO_MANIFEST_DIR"), "/echo_descriptor.bin"));
+    let tmp = TempDir::new().unwrap();
+    let svc_dir = tmp.path().join("echo");
+    fs::create_dir(&svc_dir).unwrap();
+    fs::copy(&descriptor, svc_dir.join("descriptor.bin")).unwrap();
+    fs::write(
+        svc_dir.join("config.yaml"),
+        format!("route: http://{}", server_addr),
+    )
+    .unwrap();
 
     let server_handle = tokio::spawn(server::serve(server_addr));
 
     // wait for server to start
     tokio::time::sleep(Duration::from_millis(100)).await;
 
-    let mut routes = HashMap::new();
-    routes.insert(
-        "/test.EchoService/Echo".to_string(),
-        format!("http://{}", server_addr).parse().unwrap(),
-    );
     let config = ProxyConfig {
-        descriptor_path: descriptor,
+        descriptor_root: tmp.path().to_path_buf(),
         listen: proxy_addr,
         default: format!("http://{}", server_addr).parse().unwrap(),
-        routes,
     };
     let proxy_handle = tokio::spawn(proxy::serve(config));
 
     tokio::time::sleep(Duration::from_millis(100)).await;
 
-    let mut client = test::echo_service_client::EchoServiceClient::connect(
-        format!("http://{}", proxy_addr),
-    )
-    .await
-    .unwrap();
-    let req = || Request::new(test::EchoRequest { message: "hello".into() });
+    let mut client =
+        test::echo_service_client::EchoServiceClient::connect(format!("http://{}", proxy_addr))
+            .await
+            .unwrap();
+    let req = || {
+        Request::new(test::EchoRequest {
+            message: "hello".into(),
+        })
+    };
     let resp1 = client.echo(req()).await.unwrap().into_inner();
     assert_eq!(resp1.message, "hello");
 


### PR DESCRIPTION
## Summary
- load FileDescriptorSet descriptors from a root folder
- update proxy CLI to accept a descriptor root
- update integration test to build temporary descriptor directories
- add serde/serde_yaml/tempfile deps

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6879caaae3048324bc073cfc2a7408f1